### PR TITLE
use SLURM_STEP_RESV_PORTS to prevent port conflicts

### DIFF
--- a/MultiProcPerGPU_DPPMPI.py
+++ b/MultiProcPerGPU_DPPMPI.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     gpu_ids = os.environ['SLURM_STEP_GPUS'].split(",")
 
     os.environ['MASTER_ADDR'] = hostnames[0]
-    os.environ['MASTER_PORT'] = str(6512)
+    os.environ['MASTER_PORT'] = str(os.environ['SLURM_STEP_RESV_PORTS'].split("-")[0])
 
     # assert len(gpu_ids) == 1
     gpu_id = int(gpu_ids[0])

--- a/slurmTorch.py
+++ b/slurmTorch.py
@@ -14,6 +14,8 @@ local_rank = int(os.environ['SLURM_LOCALID'])
 size = int(os.environ['SLURM_NTASKS'])
 cpus_per_task = int(os.environ['SLURM_CPUS_PER_TASK'])
 local_nodeID = int(os.environ["SLURM_NODEID"])
+resv_ports = os.environ['SLURM_STEP_RESV_PORTS'].split("-")
+first_port = int(resv_ports[0])
 
 # get node list from slurm
 hostnames = hostlist.expand_hostlist(os.environ['SLURM_JOB_NODELIST'])
@@ -23,4 +25,4 @@ gpu_ids = os.environ['SLURM_STEP_GPUS'].split(",")
     
 # define MASTER_ADD & MASTER_PORT
 os.environ['MASTER_ADDR'] = hostnames[0]
-os.environ['MASTER_PORT'] = str(12345 + int(min(gpu_ids))) # to avoid port conflict on the same node
+os.environ['MASTER_PORT'] = str(first_port + rank) # to avoid port conflict on the same node


### PR DESCRIPTION
Slurm reserves min. one individual port per tasks on each jobs step. We should take this to prevent port conflicts with other users running other applications on the same node.