### PR TITLE
Revert "use SLURM_STEP_RESV_PORTS to prevent port conflicts"

### DIFF
--- a/MultiProcPerGPU_DPPMPI.py
+++ b/MultiProcPerGPU_DPPMPI.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     gpu_ids = os.environ['SLURM_STEP_GPUS'].split(",")
 
     os.environ['MASTER_ADDR'] = hostnames[0]
-    os.environ['MASTER_PORT'] = str(os.environ['SLURM_STEP_RESV_PORTS'].split("-")[0])
+    os.environ['MASTER_PORT'] = str(6512)
 
     # assert len(gpu_ids) == 1
     gpu_id = int(gpu_ids[0])

--- a/MultiProcPerGPU_DPPMPI.py
+++ b/MultiProcPerGPU_DPPMPI.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     gpu_ids = os.environ['SLURM_STEP_GPUS'].split(",")
 
     os.environ['MASTER_ADDR'] = hostnames[0]
-    os.environ['MASTER_PORT'] = str(6512)
+    os.environ['MASTER_PORT'] = str(os.environ['SLURM_STEP_RESV_PORTS'].split("-")[0])
 
     # assert len(gpu_ids) == 1
     gpu_id = int(gpu_ids[0])

--- a/MultiProcPerGPU_DPPMPI.py
+++ b/MultiProcPerGPU_DPPMPI.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     gpu_ids = os.environ['SLURM_STEP_GPUS'].split(",")
 
     os.environ['MASTER_ADDR'] = hostnames[0]
-    os.environ['MASTER_PORT'] = str(os.environ['SLURM_STEP_RESV_PORTS'].split("-")[0])
+    os.environ['MASTER_PORT'] = str(os.environ['SLURM_STEP_RESV_PORTS'].split("-")[-1])
 
     # assert len(gpu_ids) == 1
     gpu_id = int(gpu_ids[0])

--- a/slurmTorch.py
+++ b/slurmTorch.py
@@ -18,7 +18,12 @@ local_nodeID = int(os.environ["SLURM_NODEID"])
 # get node list from slurm
 hostnames = hostlist.expand_hostlist(os.environ['SLURM_JOB_NODELIST'])
     
-# get IDs of reserved GPU
-os.environ['MASTER_ADDR'] = hostnames[0]
-resv_ports = os.environ['SLURM_STEP_RESV_PORTS'].split("-")
-os.environ['MASTER_PORT'] = str(resv_ports[0])
+try:
+    # slurm reserves one port per job
+    resv_ports = os.environ['SLURM_STEP_RESV_PORTS'].split("-")
+    os.environ['MASTER_PORT'] = str(resv_ports[-1])
+    os.environ['MASTER_ADDR'] = hostnames[0]
+except KeyError:
+    print(f'WARNING from slurmTorch.py: Use Fallback MASTER_ADDR and MASTER_PORT')
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = "29500"

--- a/slurmTorch.py
+++ b/slurmTorch.py
@@ -19,8 +19,6 @@ local_nodeID = int(os.environ["SLURM_NODEID"])
 hostnames = hostlist.expand_hostlist(os.environ['SLURM_JOB_NODELIST'])
     
 # get IDs of reserved GPU
-gpu_ids = os.environ['SLURM_STEP_GPUS'].split(",")
-    
-# define MASTER_ADD & MASTER_PORT
 os.environ['MASTER_ADDR'] = hostnames[0]
-os.environ['MASTER_PORT'] = str(12345 + int(min(gpu_ids))) # to avoid port conflict on the same node
+resv_ports = os.environ['SLURM_STEP_RESV_PORTS'].split("-")
+os.environ['MASTER_PORT'] = str(resv_ports[0])

--- a/slurmTorch.py
+++ b/slurmTorch.py
@@ -14,8 +14,6 @@ local_rank = int(os.environ['SLURM_LOCALID'])
 size = int(os.environ['SLURM_NTASKS'])
 cpus_per_task = int(os.environ['SLURM_CPUS_PER_TASK'])
 local_nodeID = int(os.environ["SLURM_NODEID"])
-resv_ports = os.environ['SLURM_STEP_RESV_PORTS'].split("-")
-first_port = int(resv_ports[0])
 
 # get node list from slurm
 hostnames = hostlist.expand_hostlist(os.environ['SLURM_JOB_NODELIST'])
@@ -25,4 +23,4 @@ gpu_ids = os.environ['SLURM_STEP_GPUS'].split(",")
     
 # define MASTER_ADD & MASTER_PORT
 os.environ['MASTER_ADDR'] = hostnames[0]
-os.environ['MASTER_PORT'] = str(first_port + rank) # to avoid port conflict on the same node
+os.environ['MASTER_PORT'] = str(12345 + int(min(gpu_ids))) # to avoid port conflict on the same node


### PR DESCRIPTION
Reverts tud-zih-ki/minimalDDP#4

__Why?__ Sum of FirstPort and rank does not yield the same port on all ranks (obviously).

__But__
Keep ` os.environ['MASTER_PORT'] = str(os.environ['SLURM_STEP_RESV_PORTS'].split("-")[0])` in `MultiProcPerGPU_DPPMPI.py`.

__Does something prevents us from just using the reserved port straight away? Why calculating some port?__

Changes in c5c22035c6c02704f2a552bc984e288056e27d13
```python
resv_ports = os.environ['SLURM_STEP_RESV_PORTS'].split("-")
os.environ['MASTER_PORT'] = str(resv_ports[0])
```
 